### PR TITLE
Fixes #34: JSONObject matches loklak search result

### DIFF
--- a/scrapers/twitter.js
+++ b/scrapers/twitter.js
@@ -37,11 +37,13 @@ class TwitterLoklakScrapper extends BaseLoklakScrapper {
 			tweetDetail.user.name = $(element).attr("data-name");
 			tweetDetail.user.screen_name = $(element).attr("data-screen-name");
 
-			// status_url, time-name, time_in_millis
+			// status_url, time-name, time_in_millis, screen_name
 			tweetDetail.link = $(element).find("a.tweet-timestamp").attr("href");
 			tweetDetail.link = "https://twitter.com" + tweetDetail.link;
-			tweetDetail.created_at = $(element).find("a.tweet-timestamp").attr("title");
 			tweetDetail.timestamp = $(element).find("span._timestamp").attr("data-time-ms");
+			tweetDetail.timestamp = parseInt(tweetDetail.timestamp);
+			tweetDetail.created_at = tweetDetail.timestamp;
+			tweetDetail.screen_name = tweetDetail.user.screen_name;
 
 			// tweet_text
 			tweetDetail.text = $(element).find("p.tweet-text").text();


### PR DESCRIPTION
Solves issue: https://github.com/fossasia/loklak_scraper_js/issues/34

The scraped data's JSONObject matches the result of loklak's "search"
API, so that the scraped data can be pushed back to loklak server using
"push" API. Following changes are done:
1. Converts "timestamp" to int.
2. The value of "timestamp" is assigned to "created_at".
3. An extra "screen_name" is added in the parent object of "user".