### PR TITLE
Fixes #38: Enhances quora profile scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+build/

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
     "request-promise-native": "^1.0.4",
+    "rxjs": "^5.4.2",
     "sync-request": "^4.0.3"
   },
   "devDependencies": {

--- a/scrapers/quora.js
+++ b/scrapers/quora.js
@@ -1,6 +1,10 @@
 const BaseLoklakScrapper = require('./base');
 
-class QuoraLoklakScrapper extends BaseLoklakScrapper {
+const cheerio = require('cheerio');
+const request = require('request-promise-native');
+const Rx = require('rxjs/Rx');
+
+class QuoraProfileLoklakScraper extends BaseLoklakScrapper {
 
   constructor() {
     super('Quora', 'https://www.quora.com');
@@ -8,26 +12,49 @@ class QuoraLoklakScrapper extends BaseLoklakScrapper {
 
   argumentSanityCheck(args) {
     super.argumentSanityCheck(args);
-
-    if (args.length <= 2) {
-      console.error('Atleast one argument required.');
-      process.exit(-1);
-    }
-
     return true;
   }
 
   onInit() {
     this.REQUEST_URL = this.BASE_URL + "/profile/" + this.SLICED_PROC_ARGS[0];
-    this.request();
   }
 
+  /**
+   * Returns promise object of profile search url.
+   * @param {*string} query profile search query
+   */
+  getSearchQueryPromise(query) {
+    let profileSearchUrl = `${this.BASE_URL}/search?q=${query}&type=profile`;
+    return request(profileSearchUrl);
+  }
+
+  /**
+   * Parses links of Quora profile from search HTML and returns back an array of promise of profile
+   * urls.
+   * @param {*string} searchMatchHtml HTML of Quora profile search page
+   */
+  getProfileLinkPromises(searchMatchHtml) {
+    let profileLinks = [];
+    let $ = cheerio.load(searchMatchHtml);
+    $("a.user").each((i, elem) => {
+      let relativeLink = $(elem).attr("href");
+      let profileLink = `${this.BASE_URL}/${relativeLink}`;
+      profileLinks.push(profileLink);
+    })
+    return profileLinks.map(elem => request(elem));
+  }
+
+  /**
+   * Parses the HTML of an individual Quora profile and returns back JSONObject containing parsed
+   * data.
+   * @param {*CheerioStatic}  $ HTML parsed DOM
+   */
   scrape($) {
     const quoraProfile = {};
     const feed = {};
     const topics = [];
 
-    quoraProfile["profile_url"] = this.REQUEST_URL;
+    quoraProfile["profile_url"] = $('link[rel="canonical"]').attr("href");
     quoraProfile["bio"] = $(".ProfileDescription").text();
     quoraProfile["profile_image"] = $(".profile_photo_img").attr("src");
     quoraProfile["user_name"] = $(".profile_photo_img").attr("alt");
@@ -35,8 +62,8 @@ class QuoraLoklakScrapper extends BaseLoklakScrapper {
     quoraProfile["rss_feed_link"] = rssFeedLink;
 
     var stats = $(".list_count");
-    for (var i = 0;i < stats.length; i++) {
-      var stat=stats[i];
+    for (var i = 0; i < stats.length; i++) {
+      var stat = stats[i];
       feed[stat.prev.data.toLowerCase().trim() + "_url"] = this.BASE_URL + stat.parent.attribs.href;
       feed[stat.prev.data.toLowerCase().trim() + "_count"] = stat.children[0].data;
     }
@@ -57,16 +84,46 @@ class QuoraLoklakScrapper extends BaseLoklakScrapper {
       topics.push($(elem).text());
     });
     quoraProfile["knows_about"] = topics;
+    return quoraProfile;
+  }
 
-    this.JSON = quoraProfile;
+  /**
+   * Uses the scrape method to scrape Quora profiles from quora and passed the data
+   * to callback function.
+   * @param {*string} query quora profile search query
+   * @param {*function} callback callback function to be invoked after completion
+   */
+  getScrapedData(query, callback) {
+    Rx.Observable.fromPromise(this.getSearchQueryPromise(query))
+      .flatMap((t, i) => {
+        let profileLinkPromises = this.getProfileLinkPromises(t);
+        let obs = profileLinkPromises.map(elem => Rx.Observable.fromPromise(elem));
 
-    // Uncomment the following line for testing
-    // console.log(quoraProfile);
-
-    return this.JSON;
+        // each Quora profile is parsed
+        return Rx.Observable.zip(
+          ...obs,
+          (...profileLinkObservables) => {
+            let scrapedProfiles = [];
+            for (let i = 0; i < profileLinkObservables.length; i++) {
+              let $ = cheerio.load(profileLinkObservables[i]);
+              scrapedProfiles.push(this.scrape($));
+            }
+            return scrapedProfiles;
+          }
+        )
+      })
+      .subscribe(
+        scrapedData => callback({profiles: scrapedData}),
+        error => callback(error)
+      );
   }
 }
 
-module.exports = QuoraLoklakScrapper;
+module.exports = QuoraProfileLoklakScraper;
 
-new QuoraLoklakScrapper();
+// Use of QuoraProfileLoklakScraper
+// let quoraProfiles = new QuoraProfileLoklakScraper();
+
+// quoraProfiles.getScrapedData("Rahul", (data) => {
+//   console.log(data);
+// });


### PR DESCRIPTION
Quora profiles are queried using https://www.quora.com/search?q=QUERY&type=profile url.
Link of profiles are extracted from the search page and then individual
profiles are scraped.