### PR TITLE
Fixes #56 - Added test framework and tests for Github profile scraper

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Scrapers for loklak in JavaScript",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha --reporter spec"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,9 @@
   },
   "homepage": "https://github.com/fossasia/loklak_scraper_js#readme",
   "dependencies": {
+    "chai": "^4.1.1",
     "cheerio": "^1.0.0-rc.1",
+    "mocha": "^3.5.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
     "request-promise-native": "^1.0.4",

--- a/test/github-spec.js
+++ b/test/github-spec.js
@@ -1,0 +1,32 @@
+const GithubProfileScraper = require('../scrapers/github')
+
+let githubProfileScraper = new GithubProfileScraper();
+
+var expect    = require("chai").expect;
+
+const userId = 16368427;
+const userName = "djmgit";
+const avatarUrl = "https://avatars0.githubusercontent.com/u/16368427?v=4";
+const atomFeedLink = "https://github.com/djmgit.atom";
+const fullName = "Deepjyoti Mondal";
+const specialLink = "http://djmgit.github.io";
+const joiningDate = "2015-12-20";
+
+describe("Test GithubProfileScraper", function() {
+    describe("Testing profile data", function() {
+  	    this.timeout(60000);
+
+        it("contains basic user profile data", function(done) {
+    	      githubProfileScraper.getScrapedData("djmgit", data => {
+    		        expect(data["user_id"]).to.equal(userId);
+    		        expect(data["user_name"]).to.equal(userName);
+    		        expect(data["avatar_url"]).to.equal(avatarUrl);
+    		        expect(data["atom_feed_link"]).to.equal(atomFeedLink);
+    		        expect(data["full_name"]).to.equal(fullName);
+    		        expect(data["special_link"]).to.equal(specialLink);
+    		        expect(data["joining_date"]).to.equal(joiningDate);
+    		        done();
+    	      });
+        });
+    });  
+});


### PR DESCRIPTION
Fixes issue #56, added test framework and tests for Github
profile scraper using mocha and chai.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
